### PR TITLE
File mode support

### DIFF
--- a/spx/spxflask.py
+++ b/spx/spxflask.py
@@ -43,7 +43,13 @@ class spxSnippetHandler(MethodView):
         sp = spxSnippet()
         try:
             sp.dictToObj(p)
-            sp.stripXSS()
+
+            if sp.isFile:
+                sp.stripFile()
+            else:
+                sp.isRaw = False
+                sp.stripXSS()
+
             sp.encrypt()
         except spxException as e:
             ret = {'rc': e.rc, 'error': e.msg}

--- a/spx/spxsnippet.py
+++ b/spx/spxsnippet.py
@@ -33,7 +33,6 @@ class spxSnippet(spxMongoObject):
     _attrs = {
             'id': '_id',
             'content': 'content',
-            'file': 'file',
             'reference': 'reference',
             'email': 'email',
             'createdBy': 'createdBy',
@@ -54,7 +53,6 @@ class spxSnippet(spxMongoObject):
         self.isFile = False
         self.isConfirm = False
         self.email = ''
-        self.file = ''
         self.reference = ''
         self.created = created
         if self.created is None:

--- a/spx/spxsnippet.py
+++ b/spx/spxsnippet.py
@@ -33,6 +33,7 @@ class spxSnippet(spxMongoObject):
     _attrs = {
             'id': '_id',
             'content': 'content',
+            'file': 'file',
             'reference': 'reference',
             'email': 'email',
             'createdBy': 'createdBy',
@@ -53,6 +54,7 @@ class spxSnippet(spxMongoObject):
         self.isFile = False
         self.isConfirm = False
         self.email = ''
+        self.file = ''
         self.reference = ''
         self.created = created
         if self.created is None:
@@ -102,6 +104,16 @@ class spxSnippet(spxMongoObject):
         with smtplib.SMTP(smtp_addr) as smtp:
             smtp.sendmail(mail_from, self.email, msg.as_string())
             smtp.quit()
+
+    def stripFile(self):
+        """ should remove: data:*/*;base64, from the begining of the field """
+        tmp = self.content.split(',', 1)
+
+        if len(tmp) != 2:
+            raise spxException(rc=-6, msg='File format incorrect')
+
+        self.content = tmp[1]
+
 
     def stripXSS(self):
         x = XssCleaner(remove_all=self.isRaw)
@@ -178,7 +190,12 @@ class spxSnippet(spxMongoObject):
             else:
                 self.reference = d['reference']
 
+        if 'isFile' in d:
+            if d['isFile'] is True or d['isFile'] == 'True' or d['isFile'] == 1:
+                self.isFile = True
+
         self.content = d['content']
+
         self.createdBy = d['createdBy']
 
 

--- a/spx/spxsnippet.py
+++ b/spx/spxsnippet.py
@@ -37,6 +37,7 @@ class spxSnippet(spxMongoObject):
             'email': 'email',
             'createdBy': 'createdBy',
             'isRaw': 'isRaw',
+            'isFile': 'isFile',
             'isConfirm': 'isConfirm',
             'created': 'created',
             }
@@ -49,6 +50,7 @@ class spxSnippet(spxMongoObject):
         self.content = content
         self.createdBy = createdBy
         self.isRaw = False
+        self.isFile = False
         self.isConfirm = False
         self.email = ''
         self.reference = ''
@@ -152,6 +154,7 @@ class spxSnippet(spxMongoObject):
             raise spxException(rc=-1, msg='createdBy not provided')
 
         self.isRaw = False
+        self.isFile = False
         self.isConfirm = False
 
         if 'isConfirm' in d:
@@ -188,6 +191,7 @@ class spxSnippet(spxMongoObject):
         """ rs['createdBy'] = self.createdBy we don't want to disclose who has created the snippet """
         rs['created'] = self.created
         rs['isRaw'] = self.isRaw
+        rs['isFile'] = self.isFile
         if isBck == True:
             rs['isConfirm'] = self.isConfirm
             rs['email'] = self.email

--- a/spx/spxsnippet.py
+++ b/spx/spxsnippet.py
@@ -35,6 +35,7 @@ class spxSnippet(spxMongoObject):
             'content': 'content',
             'reference': 'reference',
             'email': 'email',
+            'name': 'name',
             'createdBy': 'createdBy',
             'isRaw': 'isRaw',
             'isFile': 'isFile',
@@ -53,6 +54,7 @@ class spxSnippet(spxMongoObject):
         self.isFile = False
         self.isConfirm = False
         self.email = ''
+        self.name = ''
         self.reference = ''
         self.created = created
         if self.created is None:
@@ -192,6 +194,9 @@ class spxSnippet(spxMongoObject):
             if d['isFile'] is True or d['isFile'] == 'True' or d['isFile'] == 1:
                 self.isFile = True
 
+        if 'name' in d:
+            self.name = d['name']
+
         self.content = d['content']
 
         self.createdBy = d['createdBy']
@@ -207,6 +212,7 @@ class spxSnippet(spxMongoObject):
         rs['created'] = self.created
         rs['isRaw'] = self.isRaw
         rs['isFile'] = self.isFile
+        rs['name'] = self.name
         if isBck == True:
             rs['isConfirm'] = self.isConfirm
             rs['email'] = self.email

--- a/spx/spxsnippet.py
+++ b/spx/spxsnippet.py
@@ -106,6 +106,9 @@ class spxSnippet(spxMongoObject):
     def stripFile(self):
         """ should remove: data:*/*;base64, from the begining of the field """
         tmp = self.content.split(',', 1)
+        # Fetch MIME
+        mime = tmp[0]
+        mime = mime.split(':', 1)
 
         if len(tmp) != 2:
             raise spxException(rc=-6, msg='File format incorrect')

--- a/spx/spxsnippet.py
+++ b/spx/spxsnippet.py
@@ -106,9 +106,6 @@ class spxSnippet(spxMongoObject):
     def stripFile(self):
         """ should remove: data:*/*;base64, from the begining of the field """
         tmp = self.content.split(',', 1)
-        # Fetch MIME
-        mime = tmp[0]
-        mime = mime.split(':', 1)
 
         if len(tmp) != 2:
             raise spxException(rc=-6, msg='File format incorrect')

--- a/static/index.html
+++ b/static/index.html
@@ -59,7 +59,7 @@
  
                 </div>
 
-                <div class="row was-validated">
+                <div id="contentInput" class="row was-validated">
                     <div class="form-group col-md-12">
                         <label for=inputContent">Insert the content of the snippet below</label>
                         <textarea class="form-control is-invalid" style="height: 50vh;" id="content" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" required></textarea>

--- a/static/index.html
+++ b/static/index.html
@@ -99,7 +99,7 @@
                         <input class="btn btn-sm btn-block btn-primary btn-create" type="button" onClick="snippetSubmit();" value="Create" />
                     </div>
                     <div class="col-md-2 custom-control custom-switch">
-                        <input type="checkbox" class="custom-control-input" onClick="toggleFileMode();" id="advancedFile">
+                        <input type="checkbox" class="custom-control-input" onClick="toggleFileMode();" id="fileMode">
                         <label class="custom-control-label" for="fileMode">File Mode</label>
                     </div>
                     <div class="col-md-2 custom-control custom-switch">

--- a/static/index.html
+++ b/static/index.html
@@ -51,7 +51,7 @@
                 
             <div id="createForm">
 
-                <div class="row" id="advancedInput" style="display: none;">
+                <div class="row" id="fileInput" style="display: none;">
                     <div class="form-group col-md-12">
                         <label for=inputFile">Select the file to upload and encrypt below</label>
                         <input type="file" class="form-control" id="content" required/>

--- a/static/index.html
+++ b/static/index.html
@@ -51,6 +51,14 @@
                 
             <div id="createForm">
 
+                <div class="row" id="advancedInput" style="display: none;">
+                    <div class="form-group col-md-12">
+                        <label for=inputFile">Select the file to upload and encrypt below</label>
+                        <input type="file" class="form-control" id="content" required/>
+                    </div>
+ 
+                </div>
+
                 <div class="row was-validated">
                     <div class="form-group col-md-12">
                         <label for=inputContent">Insert the content of the snippet below</label>
@@ -89,6 +97,10 @@
                 <div class="row justify-content-between pt-3">
                     <div class="form-group col-md-2">
                         <input class="btn btn-sm btn-block btn-primary btn-create" type="button" onClick="snippetSubmit();" value="Create" />
+                    </div>
+                    <div class="col-md-2 custom-control custom-switch">
+                        <input type="checkbox" class="custom-control-input" onClick="toggleFileMode();" id="advancedFile">
+                        <label class="custom-control-label" for="fileMode">File Mode</label>
                     </div>
                     <div class="col-md-2 custom-control custom-switch">
                         <input type="checkbox" class="custom-control-input" onClick="toggleAdvancedMode();" id="advancedMode">

--- a/static/index.html
+++ b/static/index.html
@@ -54,7 +54,7 @@
                 <div class="row" id="fileInput" style="display: none;">
                     <div class="form-group col-md-12">
                         <label for=inputFile">Select the file to upload and encrypt below</label>
-                        <input type="file" class="form-control" id="content" required/>
+                        <input type="file" class="form-control-file" id="inputFile" required/>
                     </div>
  
                 </div>

--- a/static/js/snippet.js
+++ b/static/js/snippet.js
@@ -73,7 +73,7 @@ function snippetSubmit() {
             $('#msgError').show();
             return;
         }
-        opts['file'] = btoa(file[0])
+        opts['file'] = btoa(file[0].getAsBinary())
     } else {
         if (opts['content'] == '') {
             $('#msgError').text('You should fill the snippet!');

--- a/static/js/snippet.js
+++ b/static/js/snippet.js
@@ -193,7 +193,7 @@ function getSnippet() {
                         var blob = base64ToBlob(data['content'], 'application/octet-stream');
                         var url = window.URL.createObjectURL(blob);
                         a.href = url;
-                        a.download = result.download.filename;
+                        a.download = data['name'];
                         a.click();
                         window.URL.revokeObjectURL(url);
                     } else {

--- a/static/js/snippet.js
+++ b/static/js/snippet.js
@@ -73,7 +73,7 @@ function snippetSubmit() {
             $('#msgError').show();
             return;
         }
-        opts['file'] = btoa(file[0].getAsBinary())
+        opts['file'] = btoa(file[0].stream())
     } else {
         if (opts['content'] == '') {
             $('#msgError').text('You should fill the snippet!');

--- a/static/js/snippet.js
+++ b/static/js/snippet.js
@@ -80,7 +80,7 @@ function snippetSubmit() {
             $('#msgError').show();
             return;
         }
-        opts['name'] = file.name;
+        opts['name'] = file[0].name;
         var reader = new FileReader();
         reader.onerror = function(error) {
             $('#msgError').text(data.error);

--- a/static/js/snippet.js
+++ b/static/js/snippet.js
@@ -73,7 +73,7 @@ function snippetSubmit() {
     }
     url = null;
     if (opts['isFile']) {
-        var file = $('#inputFile').files[0];
+        var file = $('#inputFile')[0].files;
         if (file.length != 1) {
             $('#msgError').text('You should select a file while in File Mode!');
             $('#msgError').show();
@@ -118,7 +118,7 @@ function snippetSubmit() {
                 }
             });
         };
-        reader.readAsDataURL(file);
+        reader.readAsDataURL(file[0]);
         return;
     } else {
         if (opts['content'] == '') {

--- a/static/js/snippet.js
+++ b/static/js/snippet.js
@@ -73,7 +73,7 @@ function snippetSubmit() {
             $('#msgError').show();
             return;
         }
-        var fd = FormData();
+        var fd = new FormData();
         fd.append('file', file[0])
         opts['file'] = fd['file'];
     } else {

--- a/static/js/snippet.js
+++ b/static/js/snippet.js
@@ -33,6 +33,15 @@ function loadSnippetPage() {
 }
 
 /*
+ * Base64-ify
+ */
+function getBase64(file) {
+   var reader = new FileReaderSync();
+   reader.readAsDataURL(file);
+   return reader.result;
+}
+
+/*
  * Submit snippet to API for creation.
  */
 function snippetSubmit() {
@@ -42,6 +51,7 @@ function snippetSubmit() {
     opts = {};
     opts['content'] = $('#content').val();
     opts['isRaw'] = 0;
+    opts['isFile'] = 0;
     opts['isConfirm'] = 0;
     opts['email'] = '';
     opts['reference'] = '';
@@ -62,10 +72,20 @@ function snippetSubmit() {
     if ($('#snippet_confirm').prop('checked')) {
         opts['isConfirm'] = 1;
     }
-    if (opts['content'] == '') {
-        $('#msgError').text('You should fill the snippet!');
-        $('#msgError').show();
-        return;
+    if (opts['isFile']) {
+        var file = $('#file')[0].files;
+        if (file.length != 1) {
+            $('#msgError').text('You should select a file while in File Mode!');
+            $('#msgError').show();
+            return;
+        }
+        opts['file'] = getBase64(file[0]);
+    } else {
+        if (opts['content'] == '') {
+            $('#msgError').text('You should fill the snippet!');
+            $('#msgError').show();
+            return;
+        }
     }
     if (opts['isConfirm'] == 1 && (opts['email'] == '' || opts['reference'] == '')) {
         $('#msgError').text('Email and Reference must be filled if you want read confirmation.');
@@ -146,6 +166,14 @@ function getSnippet() {
             $('#header').hide();
         }
     });
+}
+
+function toggleFileMode() {
+    if ($('#fileMode').prop('checked')) {
+        $('#fileInput').show();
+    } else {
+        $('#fileInput').hide();
+    }
 }
 
 function toggleAdvancedMode() {

--- a/static/js/snippet.js
+++ b/static/js/snippet.js
@@ -45,6 +45,7 @@ function snippetSubmit() {
     opts['isFile'] = 0;
     opts['isConfirm'] = 0;
     opts['email'] = '';
+    opts['name'] = '';
     opts['reference'] = '';
     if ($('#snippet_reference').val() != '') {
         opts['reference'] = $('#snippet_reference').val();
@@ -79,6 +80,7 @@ function snippetSubmit() {
             $('#msgError').show();
             return;
         }
+        opts['name'] = file.name;
         var reader = new FileReader();
         reader.onerror = function(error) {
             $('#msgError').text(data.error);

--- a/static/js/snippet.js
+++ b/static/js/snippet.js
@@ -33,15 +33,6 @@ function loadSnippetPage() {
 }
 
 /*
- * Base64-ify
- */
-function getBase64(file) {
-   var reader = new FileReaderSync();
-   reader.readAsDataURL(file);
-   return reader.result;
-}
-
-/*
  * Submit snippet to API for creation.
  */
 function snippetSubmit() {
@@ -82,7 +73,9 @@ function snippetSubmit() {
             $('#msgError').show();
             return;
         }
-        opts['file'] = getBase64(file[0]);
+        var fd = FormData();
+        fd.append('file', file[0])
+        opts['file'] = fd['file'];
     } else {
         if (opts['content'] == '') {
             $('#msgError').text('You should fill the snippet!');

--- a/static/js/snippet.js
+++ b/static/js/snippet.js
@@ -73,9 +73,7 @@ function snippetSubmit() {
             $('#msgError').show();
             return;
         }
-        var fd = new FormData();
-        fd.append('file', file[0])
-        opts['file'] = fd['file'];
+        opts['file'] = btoa(file[0])
     } else {
         if (opts['content'] == '') {
             $('#msgError').text('You should fill the snippet!');

--- a/static/js/snippet.js
+++ b/static/js/snippet.js
@@ -73,7 +73,7 @@ function snippetSubmit() {
     }
     url = null;
     if (opts['isFile']) {
-        var file = $('#inputFile')[0].files;
+        var file = $('#inputFile').files[0];
         if (file.length != 1) {
             $('#msgError').text('You should select a file while in File Mode!');
             $('#msgError').show();

--- a/static/js/snippet.js
+++ b/static/js/snippet.js
@@ -73,7 +73,7 @@ function snippetSubmit() {
         opts['isConfirm'] = 1;
     }
     if (opts['isFile']) {
-        var file = $('#file')[0].files;
+        var file = $('#inputFile')[0].files;
         if (file.length != 1) {
             $('#msgError').text('You should select a file while in File Mode!');
             $('#msgError').show();

--- a/static/js/snippet.js
+++ b/static/js/snippet.js
@@ -66,6 +66,9 @@ function snippetSubmit() {
             return;
         }
     }
+    if ($('#fileMode').prop('checked')) {
+        opts['isFile'] = 1;
+    }
     if ($('#snippet_isRaw').prop('checked')) {
         opts['isRaw'] = 1;
     }

--- a/static/js/snippet.js
+++ b/static/js/snippet.js
@@ -170,9 +170,11 @@ function getSnippet() {
 
 function toggleFileMode() {
     if ($('#fileMode').prop('checked')) {
+        $('#contentInput').hide();
         $('#fileInput').show();
     } else {
         $('#fileInput').hide();
+        $('#contentInput').show();
     }
 }
 

--- a/static/js/snippet.js
+++ b/static/js/snippet.js
@@ -86,7 +86,7 @@ function snippetSubmit() {
             return;
         };
         reader.onload = function() {
-            opts['file'] = reader.result;
+            opts['content'] = reader.result;
             $.ajax({
                 type: 'POST',
                 url: '/api/snippet',

--- a/static/view.html
+++ b/static/view.html
@@ -49,6 +49,8 @@
                         <p>Clicking the following button will reveal confidential information, This action will also <b>DELETE</b> the data from the server and it will consequently be impossible to be read a second time!</p>
                         <hr/>
                         <p>You can only get this information <b>ONE TIME</b>, please make sure you save it as needed!</p>
+                        <hr/>
+                        <p><b>NOTE:</b> If the snippet is a file, a download prompt will be presented to you, if you don't download it, the file will be forever lost!</p>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
This PR is adding a File Mode on the snippet tool. This allows to:

- Upload file which gets encrypted the same way the snippet was.
- Allow that file to be fetched only one time by the receiver of the URL.

Once the file has been downloaded, even if the download is rejected or the file is not saved, the original uploaded file is gone forever.

Potential caveats:

- the filename is not XSS stripped (or not stripped at all for anything malicious)
- Of course, filename is not stripped, scanned or anything else, so use this at your own risks.