### PR TITLE
Fix snippet equality comparisons

### DIFF
--- a/spx/spxsnippet.py
+++ b/spx/spxsnippet.py
@@ -60,14 +60,14 @@ class spxSnippet(spxMongoObject):
             self.created = int(time.time())
 
     def __eq__(self, other):
-        if self.id == other.id:
-            return True
-        return False
+        if isinstance(other, spxSnippet):
+            return self.id == other.id
+        return NotImplemented
 
     def __ne__(self, other):
-        if self.id != other.id:
-            return True
-        return False
+        if isinstance(other, spxSnippet):
+            return self.id != other.id
+        return NotImplemented
 
     def __str__(self):
         return str(self.id)


### PR DESCRIPTION
## Summary
- avoid AttributeError in snippet comparison by type checking

## Testing
- `python -m py_compile spx/spxsnippet.py`
- `python - <<'PY'
from spx.spxsnippet import spxSnippet
s = spxSnippet()
print(s == s)
print(s == 5)
print(s != s)
print(s != 5)
PY`

------
https://chatgpt.com/codex/tasks/task_b_687f8a4aafb4832d8c3890c85f865c7a