### PR TITLE
Fix UTF-8 encoding for secure snippet email/reference

### DIFF
--- a/spx/spxsnippet.py
+++ b/spx/spxsnippet.py
@@ -130,10 +130,10 @@ class spxSnippet(spxMongoObject):
         self.content = base64.b64encode(iv + cryptbytes)
 
         if len(self.email) > 0:
-            self.email = base64.b64encode(cipher.encrypt(self.email))
+            self.email = base64.b64encode(cipher.encrypt(self.email.encode("utf-8")))
 
         if len(self.reference) > 0:
-            self.reference = base64.b64encode(cipher.encrypt(self.reference))
+            self.reference = base64.b64encode(cipher.encrypt(self.reference.encode("utf-8")))
 
     def decrypt(self, key):
         if len(key) != 32:


### PR DESCRIPTION
## Summary
- ensure encrypt() encodes email and reference as UTF-8 before encryption

## Testing
- `python -m py_compile spx/*.py snippet.py`

------
https://chatgpt.com/codex/tasks/task_b_687f8c26f2dc832dafe75a8e24261440