### PR TITLE
Add test for snippet encryption/decryption

### DIFF
--- a/tests/test_snippet.py
+++ b/tests/test_snippet.py
@@ -1,0 +1,31 @@
+import os
+import sys
+import pytest
+
+# Add repository root to path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from spx.spxsnippet import spxSnippet
+
+
+def test_encrypt_decrypt():
+    original_content = 'hello world'
+    original_email = b'user@example.com'
+    original_reference = b'ref123'
+
+    snip = spxSnippet(content=original_content)
+    snip.email = original_email
+    snip.reference = original_reference
+
+    snip.encrypt()
+    key = snip.clearKey
+
+    # after encryption content should not equal original and be bytes
+    assert snip.content != original_content
+    assert isinstance(snip.content, (bytes, bytearray))
+
+    assert snip.decrypt(key) is True
+
+    assert snip.content == original_content
+    assert snip.email == original_email.decode()
+    assert snip.reference == original_reference.decode()


### PR DESCRIPTION
## Summary
- add unit test verifying spxSnippet encryption and decryption

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687f8c399cbc832db11c52e289e54faa