### PR TITLE
Secure random key generation for snippets

### DIFF
--- a/spx/spxutils.py
+++ b/spx/spxutils.py
@@ -1,5 +1,6 @@
 import string
-import random
+import secrets
 
 def randString(size=32, chars=string.ascii_letters + string.digits):
-         return ''.join(random.choice(chars) for x in range(size))
+    """Return a cryptographically secure random string."""
+    return ''.join(secrets.choice(chars) for _ in range(size))

--- a/tests/test_snippet.py
+++ b/tests/test_snippet.py
@@ -10,8 +10,8 @@ from spx.spxsnippet import spxSnippet
 
 def test_encrypt_decrypt():
     original_content = 'hello world'
-    original_email = b'user@example.com'
-    original_reference = b'ref123'
+    original_email = 'user@example.com'
+    original_reference = 'ref123'
 
     snip = spxSnippet(content=original_content)
     snip.email = original_email
@@ -27,5 +27,5 @@ def test_encrypt_decrypt():
     assert snip.decrypt(key) is True
 
     assert snip.content == original_content
-    assert snip.email == original_email.decode()
-    assert snip.reference == original_reference.decode()
+    assert snip.email == original_email
+    assert snip.reference == original_reference


### PR DESCRIPTION
## Summary
- use `secrets` instead of `random` in `randString`
- adjust snippet tests to use string fields

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6880e01509d4832d8462c26ba05fba7b