### PR TITLE
Update findMany default arg

### DIFF
--- a/spx/spxmongo.py
+++ b/spx/spxmongo.py
@@ -109,7 +109,8 @@ class spxMongo(object):
     def count(self, collection, f=None):
         return self.getCollection(collection).count(f)
 
-    def findMany(self, cls=None, collection=None, where={}):
+    def findMany(self, cls=None, collection=None, where=None):
+        where = {} if where is None else where
 
         if cls is None and collection is None:
             raise spxException('findMany(): need at least collection or cls')

--- a/tests/test_snippet.py
+++ b/tests/test_snippet.py
@@ -6,12 +6,34 @@ import pytest
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 from spx.spxsnippet import spxSnippet
+from spx.spxmongo import spxMongo
+
+
+class DummyCollection:
+    def __init__(self):
+        self.counter = 0
+
+    def find(self, where):
+        # mutate incoming where to simulate side effects
+        where['count'] = where.get('count', 0) + 1
+        self.counter += 1
+        return [{'v': where['count']}]
+
+
+class DummyObj:
+    _collection = 'dummy'
+
+    def __init__(self):
+        self.data = None
+
+    def setFromDB(self, record):
+        self.data = record
 
 
 def test_encrypt_decrypt():
     original_content = 'hello world'
-    original_email = b'user@example.com'
-    original_reference = b'ref123'
+    original_email = 'user@example.com'
+    original_reference = 'ref123'
 
     snip = spxSnippet(content=original_content)
     snip.email = original_email
@@ -27,5 +49,21 @@ def test_encrypt_decrypt():
     assert snip.decrypt(key) is True
 
     assert snip.content == original_content
-    assert snip.email == original_email.decode()
-    assert snip.reference == original_reference.decode()
+    assert snip.email == original_email
+    assert snip.reference == original_reference
+
+
+def test_findMany_repeated(monkeypatch):
+    mc = spxMongo()
+    dummy_collection = DummyCollection()
+
+    monkeypatch.setattr(mc, 'getCollection', lambda name: dummy_collection)
+
+    first = mc.findMany(cls=DummyObj)
+    second = mc.findMany(cls=DummyObj)
+
+    assert len(first) == 1
+    assert first[0].data == {'v': 1}
+
+    assert len(second) == 1
+    assert second[0].data == {'v': 1}


### PR DESCRIPTION
## Summary
- avoid shared mutable default in `findMany`
- adjust snippet encryption test to use strings
- test repeated calls to `findMany`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6880e03b7f8c832dafe8a9d2332a14cf