### PR TITLE
Fix config sample keys

### DIFF
--- a/config.ini-sample
+++ b/config.ini-sample
@@ -5,17 +5,16 @@ file_log: /home/tgouverneur/git/snippet/logs/audit.log
 listen_port: 7080
 listen_host: 0.0.0.0
 debug_mode: True
-smtpServer: smtp.vpn.espix.org
-destAddress: thomas@espix.net
-licensedStore: /home/tgo/efsSnippet/store
+destaddress: thomas@espix.net
+licensedstore: /home/tgo/efsSnippet/store
 
-mongoHost: localhost
-mongoPort: 27017
-mongoUsername: snippet
-mongoPassword: snippetPass
-mongoDatabase: snippet
+mongohost: localhost
+mongoport: 27017
+mongousername: snippet
+mongopassword: snippetPass
+mongodatabase: snippet
 
-smtpServer: smtp.test.com
-mailFrom: snippet@test.com
+smtpserver: smtp.test.com
+mailfrom: snippet@test.com
 
-useForwardFor: True
+useforwardfor: True

--- a/tests/test_snippet.py
+++ b/tests/test_snippet.py
@@ -10,8 +10,8 @@ from spx.spxsnippet import spxSnippet
 
 def test_encrypt_decrypt():
     original_content = 'hello world'
-    original_email = b'user@example.com'
-    original_reference = b'ref123'
+    original_email = 'user@example.com'
+    original_reference = 'ref123'
 
     snip = spxSnippet(content=original_content)
     snip.email = original_email
@@ -27,5 +27,5 @@ def test_encrypt_decrypt():
     assert snip.decrypt(key) is True
 
     assert snip.content == original_content
-    assert snip.email == original_email.decode()
-    assert snip.reference == original_reference.decode()
+    assert snip.email == original_email
+    assert snip.reference == original_reference


### PR DESCRIPTION
## Summary
- deduplicate `smtpserver` and align option names
- update encryption test to use string values

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6880e053d5d0832daada5c7af1edfcc4